### PR TITLE
Use draft PR for autogenerated PR

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -59,7 +59,7 @@ jobs:
           git add .
           git commit -m "${COMMIT_TITLE}"
           git push --set-upstream origin "${SOURCE_BRANCH}"
-          gh pr create --title "${COMMIT_TITLE}" --body "${COMMIT_TITLE}" --base "${DEST_BRANCH}" --head "${SOURCE_BRANCH}"
+          gh pr create --draft --title "${COMMIT_TITLE}" --body "${COMMIT_TITLE}" --base "${DEST_BRANCH}" --head "${SOURCE_BRANCH}"
         env:
           SOURCE_BRANCH: bump-${{ steps.date.outputs.date }}
           DEST_BRANCH: master


### PR DESCRIPTION
https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs Pull requests created by the action using the default GITHUB_TOKEN cannot trigger other workflows.

But we need this.

Workarounds to trigger further workflow runs:
Create draft pull requests by setting the draft: always-true input, and configure your workflow to trigger ready_for_review in on: pull_request. The workflow will run when users manually click the "Ready for review" button on the draft pull requests. If the pull request is updated by the action, the always-true mode ensures that the pull request will be converted back to a draft.